### PR TITLE
Jekyll v4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _site
 .sass-cache
 .jekyll-metadata
+.jekyll-cache
 .DS_Store
 Gemfile.lock
 package-lock.json

--- a/wax_theme.gemspec
+++ b/wax_theme.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
-  spec.add_runtime_dependency 'jekyll', '~> 3.8'
+  spec.add_runtime_dependency 'jekyll', '>= 3.8', '< 4.1'
   spec.add_runtime_dependency 'wax_tasks', '>= 1.0.1', '< 1.1'
 
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/wax_theme.gemspec
+++ b/wax_theme.gemspec
@@ -8,12 +8,9 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Jekyll gem theme for Minicomp/Wax'
   spec.homepage      = 'https://github.com/minicomp/wax'
   spec.license       = 'MIT'
-
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
   spec.add_runtime_dependency 'jekyll', '>= 3.8', '< 4.1'
   spec.add_runtime_dependency 'wax_tasks', '>= 1.0.1', '< 1.1'
-
-  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'html-proofer', '~> 3.10'
 end

--- a/wax_theme.gemspec
+++ b/wax_theme.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
-  spec.add_runtime_dependency 'jekyll', '>= 3.8', '< 4.1'
-  spec.add_runtime_dependency 'wax_tasks', '>= 1.0.1', '< 1.1'
+  spec.add_runtime_dependency 'jekyll', '~> 4'
+  spec.add_runtime_dependency 'wax_tasks', '~> 1.0'
   spec.add_development_dependency 'html-proofer', '~> 3.10'
 end


### PR DESCRIPTION
- Uses jekyll 4 or greater
- Removes redundant rake requirement (already in wax_tasks)