### PR TITLE
Accpt custom image banner

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,5 +9,5 @@
   <link rel='stylesheet' href="{{ '/assets/styles.css' | absolute_url }}"/>
 
   <script type='text/javascript' src="{{ '/assets/jquery-3.2.1.min.js' | absolute_url }}"></script>
-  <noscript>Please enable JavaScript in your browser.</noscript>
+  <noscript><p>Please enable JavaScript in your browser.</p></noscript>
 </head>

--- a/_includes/parallax_image.html
+++ b/_includes/parallax_image.html
@@ -1,5 +1,5 @@
 {% if include.image %}
-  {% assign image = image %}
+  {% assign image = include.image %}
 {% else %}
   {% assign item  = site[include.collection] | where: 'pid', include.pid | first %}
   {% assign image = item.full %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
 
     {% if page.banner %}
       {% assign b = page.banner %}
-      {% include parallax_image.html collection=b.collection pid=b.pid y=b.y height=b.height %}
+      {% include parallax_image.html collection=b.collection pid=b.pid y=b.y height=b.height image=b.image %}
     {% endif %}
 
     <div id='wax-main'>

--- a/index.md
+++ b/index.md
@@ -2,7 +2,9 @@
 layout: page
 show_title: false
 banner:
-  image: 'https://cdn.pixabay.com/photo/2019/06/05/14/27/forest-4253766_1280.jpg'
+  collection: qatar
+  pid: obj10
+  y: 25%
   height: '500px'
 ---
 

--- a/index.md
+++ b/index.md
@@ -2,9 +2,7 @@
 layout: page
 show_title: false
 banner:
-  collection: qatar
-  pid: obj10
-  y: 25%
+  image: 'https://cdn.pixabay.com/photo/2019/06/05/14/27/forest-4253766_1280.jpg'
   height: '500px'
 ---
 


### PR DESCRIPTION
Adds feature: #59 

tl,dr: 
- banners/parallax image components will now accept a direct image url via `image` parameter.
- if `image` is not present, it will use previous/default behavior + look for a collection item via `collection` and `pid`
- Styling parameters, e.g., `y`, and `height` still apply