### PR TITLE
Make parallax image clickable

### DIFF
--- a/_exhibits/a.md
+++ b/_exhibits/a.md
@@ -11,7 +11,7 @@ Ut eleifend lacus at erat efficitur bibendum. Ut laoreet elit nec dolor molestie
 Nam velit leo, mattis ac dui non, vulputate porttitor sapien. Praesent in aliquet dui. Nulla facilisi. Maecenas nulla ex, facilisis non aliquet ac, ultrices eu sem. Sed vel aliquet urna. Mauris quis ex at lectus iaculis elementum id id massa. Integer luctus nulla vel tellus rutrum, ac pulvinar erat finibus. Aliquam erat volutpat. Pellentesque vel velit sit amet mauris dignissim feugiat.
 
 
-{% include parallax_image.html collection='qatar' pid='obj12' y='50%' %}
+{% include parallax_image.html collection='qatar' pid='obj12' y='50%' clickable='true' %}
 
 
 Duis commodo ligula libero, a pharetra ligula posuere sit amet. Sed ipsum dolor, elementum eget nisl eget, sagittis vestibulum augue. Donec tincidunt mauris et nunc sagittis, nec consectetur lorem tristique. Nulla tincidunt magna ut ullamcorper consectetur. Nulla mi urna, feugiat sed massa non, ullamcorper efficitur dolor.[^2] Sed luctus, massa eget pharetra posuere, nibh sem eleifend lectus, lobortis molestie ante libero non metus. Aenean et est sit amet est pulvinar convallis vel non tortor. Nunc semper commodo fringilla. Proin eget metus eget felis faucibus aliquet. Cras ultrices turpis id nibh cursus fringilla. Aenean nec magna turpis. Suspendisse egestas tellus iaculis ante pharetra imperdiet ac at odio.

--- a/_exhibits/b.md
+++ b/_exhibits/b.md
@@ -10,7 +10,7 @@ Ut eleifend lacus at erat efficitur bibendum. Ut laoreet elit nec dolor molestie
 
 Nam velit leo, mattis ac dui non, vulputate porttitor sapien. Praesent in aliquet dui. Nulla facilisi. Maecenas nulla ex, facilisis non aliquet ac, ultrices eu sem. Sed vel aliquet urna. Mauris quis ex at lectus iaculis elementum id id massa. Integer luctus nulla vel tellus rutrum, ac pulvinar erat finibus. Aliquam erat volutpat. Pellentesque vel velit sit amet mauris dignissim feugiat.
 
-{% include inline_image.html collection='qatar' pid='obj7' %}
+{% include inline_image.html collection='qatar' pid='obj7' clickable='true' %}
 
 Duis commodo ligula libero, a pharetra ligula posuere sit amet. Sed ipsum dolor, elementum eget nisl eget, sagittis vestibulum augue. Donec tincidunt mauris et nunc sagittis, nec consectetur lorem tristique. Nulla tincidunt magna ut ullamcorper consectetur. Nulla mi urna, feugiat sed massa non, ullamcorper efficitur dolor. Sed luctus, massa eget pharetra posuere, nibh sem eleifend lectus, lobortis molestie ante libero non metus. Aenean et est sit amet est pulvinar convallis vel non tortor. Nunc semper commodo fringilla. Proin eget metus eget felis faucibus aliquet. Cras ultrices turpis id nibh cursus fringilla. Aenean nec magna turpis. Suspendisse egestas tellus iaculis ante pharetra imperdiet ac at odio.
 

--- a/_includes/parallax_image.html
+++ b/_includes/parallax_image.html
@@ -8,14 +8,22 @@
 {%- capture style -%}
   background-image: url('{{ image | absolute_url }}');
   background-position: 0% {{ include.y | default: '15%' }};
-
+  {% if include.clickable %}
+  cursor: pointer;
+  {% endif %}
   {% if include.height %}
   height: {{ include.height }} !important;
   {% endif %}
 {%- endcapture -%}
 
+{%- capture onclick -%}
+{% if include.clickable %}
+  onclick="window.location='{{ item.url | absolute_url }}'; return false;"
+{% endif %}
+{%- endcapture -%}
+
 <div class='wax-parallax full-width {% if page.banner %}top-banner{% else %}inline-parallax{% endif %}'>
-  <div class='parallax-image' style="{{ style | strip }}"></div>
+  <div class='parallax-image' style="{{ style | strip }}" {{ onclick | strip }}></div>
 
   {% if item.label %}
   <div class='parallax-caption'>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
 
     {% if page.banner %}
       {% assign b = page.banner %}
-      {% include parallax_image.html collection=b.collection pid=b.pid y=b.y height=b.height image=b.image %}
+      {% include parallax_image.html collection=b.collection pid=b.pid y=b.y height=b.height image=b.image clickable=b.clickable %}
     {% endif %}
 
     <div id='wax-main'>

--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ banner:
   collection: qatar
   pid: obj10
   y: 25%
+  clickable: yes
   height: '500px'
 ---
 


### PR DESCRIPTION
If an attribute ```clickable``` is set, either in the ```banner``` config of a page or in an ```include parallax_image.html``` element, then the div containing the parallax image gets an ```onclick``` that leads to the source image's page, and its style includes a ```cursor: pointer``` setting to let the user know that the image is clickable.