### PR TITLE
Remove async from openseadragon load

### DIFF
--- a/_includes/osd_iiif_image_viewer.html
+++ b/_includes/osd_iiif_image_viewer.html
@@ -1,5 +1,5 @@
 <div id="osd" class="image-viewer"></div>
-<script async defer src="{{ '/assets/openseadragon/openseadragon.min.js' | absolute_url }}"></script>
+<script defer src="{{ '/assets/openseadragon/openseadragon.min.js' | absolute_url }}"></script>
 
 <script>
   $(document).ready(function () {


### PR DESCRIPTION
I don't understand why this code block is labelled async defer, but it seems dangerous? AFAIK, `async` means it's not guaranteed to be run before the inline script block below; but if that happens, `OpenSeadragon` won't have a definition and the image won't load. Probably most of the time the osd page will be in cache; but it's a big block of code and I've been getting persistent problems in testing with `OpenSeadragon` not being defined when I run with caching disabled, and I can't think of another reason that would be happening besides `async defer` here.

Seems like the sort of problem that developers would rarely see, but that might be hitting a bunch of people on their first visit to any given Wax site.

You could pull the defer off too, but that would probably be bad for performance? [edit] And document.onload in jquery should wait for the deferred script to run.