### PR TITLE
Add compose.yaml for using docker-compose.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,16 @@
+services:
+    rake:
+        image: minicomp/wax
+        entrypoint: ["bundle", "exec", "rake"]
+        volumes:
+            - .:/wax
+        user: 1000:1000
+    jekyll:
+        image: minicomp/wax
+        entrypoint: ["bundle", "exec", "jekyll"]
+        command: ["serve", "--host", "0.0.0.0"]
+        volumes:
+            - .:/wax
+        ports:
+            - "4000:4000"
+        user: 1000:1000


### PR DESCRIPTION
This allows the standard commands to be used with
docker by simply replacing `bundle exec` with
`docker-compose run --rm`. The jekyll test server
can be started with `docker-compose up jekyll`.

To avoid rights issues with root-generated files
from docker, this also sets the user to 1000,
which is usually the standard user. This has to
be changed if run as another user. Correct values
can be determined with `id -u` and `id -g`.