### PR TITLE
Allow generic item to display search metadata and viewer

### DIFF
--- a/_includes/item_metadata.html
+++ b/_includes/item_metadata.html
@@ -3,10 +3,12 @@
     {% if item.value contains 'page.' %}
       {% assign key = item.value | remove: 'page.' %}
       {% assign value = page[key] %}
+    {% elsif item contains 'page.' %}
+      {% assign key = item | remove: 'page.' %}
+      {% assign value = page[key] %}
     {% else %}
       {% assign value = item.value %}
     {% endif %}
-
     {% comment %}
     Only display non-empty values
     {% endcomment %}
@@ -24,7 +26,7 @@
           {%- endcapture -%}
         {% endif %}
       {% endif %}
-        <dt>{{ item.label }}</dt>
+        <dt>{% if item.label %}{{ item.label }}{% else %}{{key | capitalize | replace: "_", " " | strip}}{% endif %}</dt>
         <dd>{{ value | strip }}</dd>
     {% endif %}
   {% endfor %}

--- a/_layouts/generic_collection_item.html
+++ b/_layouts/generic_collection_item.html
@@ -12,6 +12,10 @@ layout: default
   {% assign viewer = page.image_viewer %}
 {% elsif layout.image_viewer %}
   {% assign viewer = layout.image_viewer %}
+{% elsif page.manifest %}
+  {% assign viewer = 'openseadragon' %}
+{% else %}
+  {% assign viewer = 'default' %}
 {% endif %}
 
 {% if viewer %}
@@ -35,6 +39,12 @@ layout: default
   {% assign metadata = layout.meta %}
 {% elsif page.meta.size %}
   {% assign metadata = page.meta %}
+{% elsif site.search.main.collections[page.collection].size %}
+  {% assign metadata = "" | split: "" %}
+  {% for item in site.search.main.collections[page.collection].fields %}
+  {% assign pluspage = item | prepend: 'page.' %}
+  {% assign metadata = metadata | push: pluspage %}
+{% endfor %}
 {% endif %}
 {% if metadata.size %}
   {% include item_metadata.html meta=metadata %}


### PR DESCRIPTION
There should be a default viewer enabled in the generic collection item. Users should not have to add that manually.

Additionally, I think it is a pretty safe bet that users want their search fields displayed, otherwise how are users going to know how items got displayed.

If users want a specific set they can set it manually as it was before but I think the default view should actually have some metadata displayed. 