### PR TITLE
Update search-ui.js : typo in query config

### DIFF
--- a/assets/search-ui.js
+++ b/assets/search-ui.js
@@ -51,7 +51,7 @@ function startSearchUI(fields, indexFile, url) {
     $('input#search').on('keyup', function() {
       var results_div = $('#results');
       var query       = $(this).val();
-      var results     = index.search(query, { boolean: 'AND', expand: true });
+      var results     = index.search(query, { bool: 'AND', expand: true });
 
       results_div.empty();
       results_div.append(`<p class="results-info">Displaying ${results.length} results</p>`);


### PR DESCRIPTION
The intent of the code is to perform an `AND` query with the terms provided in the search. However, there is a typo in the search fields configuration that results in the default `OR` behavior. We should be using `bool: "AND"` instead of 'boolean: "AND"'.

See: https://github.com/weixsong/elasticlunr.js#522-boolean-model

To test on the [demo site](https://minicomp.github.io/wax/search/):
* a search with "portrait" returns 3 results.
* a search with "portrait Majnun" currently returns 4 results (`OR` behavior)
* the search should return 1 result (`AND` behavior)